### PR TITLE
Point people to the correct spec

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,5 +1,5 @@
 name: GeoJSON
-pygments: true
+highlighter: rouge
 markdown: rdiscount
 gems:
   - jekyll-redirect-from

--- a/geojson-spec.md
+++ b/geojson-spec.md
@@ -1,6 +1,6 @@
 ---
 layout:  nav
-title:   GeoJSON Specification
+title:   Obsolete
 ---
 <!-- NAV -->
 <nav id="nav">
@@ -37,8 +37,8 @@ title:   GeoJSON Specification
 * [Appendix B\. Contributors](#appendix-b-contributors)
 </nav>
 
-# The GeoJSON Format Specification
-  
+# This document is obsolete.  Please see [RFC 7946](https://tools.ietf.org/html/rfc7946) instead.
+
 <!-- Document Info -->
 <table class="docinfo">
   <tr>

--- a/index.md
+++ b/index.md
@@ -25,11 +25,11 @@ GeoJSON supports the following geometry types: `Point`, `LineString`,
 objects with additional properties are `Feature` objects. Sets of features are
 contained by `FeatureCollection` objects.
 
-## RFC 7946
+## [The GeoJSON Specification (RFC 7946)](https://tools.ietf.org/html/rfc7946)
 
 In 2015, the Internet Engineering Task Force (IETF), in conjunction with the
 original specification authors, formed a [GeoJSON
 WG](https://datatracker.ietf.org/wg/geojson/charter/) to standardize GeoJSON.
 [RFC 7946](https://tools.ietf.org/html/rfc7946) was published in August 2016
 and is the new standard specification of the GeoJSON format, replacing the
-[2008 GeoJSON specification](geojson-spec.html).
+2008 GeoJSON specification.

--- a/readme.md
+++ b/readme.md
@@ -6,14 +6,10 @@ This repository hosts the static resources for the http://geojson.org/ website. 
 
 Static resources are transformed with [Jekyll](http://jekyllrb.com/).
 
-Any pages with the `.md` extension are rendered as `.html` with [rdiscount](https://github.com/davidfstr/rdiscount) (Jekyll's default Markdown parser [doesn't do nested lists](https://github.com/bhollis/maruku/issues/55)).  So in addition to installing Jekyll, you'll want to install rdiscount.
+Any pages with the `.md` extension are rendered as `.html` with [rdiscount](https://github.com/davidfstr/rdiscount) (Jekyll's default Markdown parser [doesn't do nested lists](https://github.com/bhollis/maruku/issues/55)).  In addition to installing `jekyll`, you'll want to install `rdiscount` for Markdown parsing and `rouge` for syntax highlighting.
 
-    gem install jekyll rdiscount
+    gem install jekyll rdiscount rouge
 
 After installing Jekyll, run the following in the root of the repository to start the development server.
 
     jekyll serve --watch --safe
-
-## Toubleshooting
-
-If Jekyll fails for you (as it did for me), there's still hope.  We've already replaced the default Mardown parser (see above about `rdiscount`).  But that's not all.  The Pygments syntax highligher doesn't always cooperate.  If you get an error from `pygments/popen.rb` complaining about not being able to get the header (`MentosError`), you might be subject to this bug: <https://github.com/tmm1/pygments.rb/issues/45>.  It sounds like the official solution is upgrade Ruby and Python.  If that doesn't sound desireable, an alternative is to comment out a few lines in [`mentos.py`](https://github.com/tmm1/pygments.rb/issues/45#issuecomment-15615704).

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,3 @@
+User-agent: *
+
+Disallow: /geojson-spec.html


### PR DESCRIPTION
This more prominently links to [RFC 7946](https://tools.ietf.org/html/rfc7946) and removes the link to the obsolete spec.

![image](https://cloud.githubusercontent.com/assets/41094/25066271/a36fc458-21de-11e7-8cde-698d4b8c7949.png)

In addition, it updates the title and header of the obsolete spec and links to the correct doc.

![image](https://cloud.githubusercontent.com/assets/41094/25066279/e3b0deda-21de-11e7-880f-0c1ba7bc71e8.png)

See #22.
