### PR TITLE
Use latest jQuery

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,7 +18,7 @@
       {{ content }}
     </section>
     {% if page.shownav %}
-      <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.7/jquery.min.js"></script>
+      <script src="https://code.jquery.com/jquery-3.3.1.min.js"></script>
       <script src="/js/nav.js"></script>
     {% endif %}
   </body>


### PR DESCRIPTION
Earlier versions of jQuery have security vulnerabilities. Also Google's CDN is blocked in China - using Jquery's CDN (powered by Stackpath) will mean the JS will work in China.

REF:
- https://code.jquery.com/
- https://snyk.io/vuln/npm:jquery